### PR TITLE
plist cannot start with blank line with Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
   - pip install coveralls
 python:
   - "2.7"
-  - "3.3"
+  - "3.4"
 script:
   - coverage run normalization/ufonormalizer -t
   - normalization/ufonormalizer -t | tee /dev/stderr | grep "\*\*\*Test Failed\*\*\*"; if [[ ${PIPESTATUS[2]} == "0" ]]; then exit 1 ; fi

--- a/normalization/ufonormalizer
+++ b/normalization/ufonormalizer
@@ -462,7 +462,7 @@ def _normalizeFontInfoGuidelines(obj):
     r"""
     - Follow general guideline normalization rules.
 
-    >>> test = '''
+    >>> test = '''\
     ... <plist version="1.0">
     ...     <dict>
     ...         <key>guidelines</key>
@@ -503,7 +503,7 @@ def _normalizeFontInfoGuidelines(obj):
 
     no guidelines
     -------------
-    >>> test = '''
+    >>> test = '''\
     ... <plist version="1.0">
     ...     <dict>
     ...         <key>guidelines</key>


### PR DESCRIPTION
plistlib.readPlistFromBytes() raises "plistlib.InvalidFileException: Invalid file" when plist starts with a blank line.